### PR TITLE
Capture root classes that don't have any dependencies

### DIFF
--- a/src/jarshrink/Dependencies.java
+++ b/src/jarshrink/Dependencies.java
@@ -209,6 +209,8 @@ public class Dependencies {
             public void onClassEnd(JDepsClassOutputParser source, String className) {
                 if (!dependencies.isEmpty()) {
                     map.put(className, dependencies.toArray(new String[dependencies.size()]));
+                } else {
+                    map.put(className, new String[0]);
                 }
             }
 


### PR DESCRIPTION
Root classes from `jdeps` that don't import any non-Java classes aren't included in the dependency map. When using this on guava (v28.2-android), this resulted in 41 classes being silently ignored (according to my `println` logging). 

This MR adds root classes without dependencies to the dependency map.

Before the patch:

```
$ java -jar JarShrink.jar guava-28.2-android.jar -out guava_shrunken.jar -status -keep "com.google.common.base.Charsets"
Unpacking .jar
Analyzing dependencies
Constructing dependency-tree

Dependencies:


Scraping redundant classes
Building new .jar
Done
$ jar tvf guava_shrunken.jar
  2366 Wed Mar 31 19:31:12 EDT 2021 META-INF/MANIFEST.MF
     0 Wed Mar 31 19:31:12 EDT 2021 META-INF/
     0 Wed Mar 31 19:31:12 EDT 2021 META-INF/maven/
     0 Wed Mar 31 19:31:12 EDT 2021 META-INF/maven/com.google.guava/
     0 Wed Mar 31 19:31:12 EDT 2021 META-INF/maven/com.google.guava/guava/
 10931 Wed Mar 31 19:31:12 EDT 2021 META-INF/maven/com.google.guava/guava/pom.xml
   137 Wed Mar 31 19:31:12 EDT 2021 META-INF/maven/com.google.guava/guava/pom.properties
```

After the patch:

```
$ java -jar JarShrink.jar guava-28.2-android.jar -out guava_shrunken.jar -status -keep "com.google.common.base.Charsets"
Unpacking .jar
Analyzing dependencies
Constructing dependency-tree
keeping: com.google.common.base.Charsets

Dependencies:

com.google.common.base.Charsets

Scraping redundant classes
Building new .jar
Done
$ jar tvf guava_shrunken.jar
  2366 Wed Mar 31 19:32:54 EDT 2021 META-INF/MANIFEST.MF
     0 Wed Mar 31 19:32:54 EDT 2021 META-INF/
     0 Wed Mar 31 19:32:54 EDT 2021 META-INF/maven/
     0 Wed Mar 31 19:32:54 EDT 2021 META-INF/maven/com.google.guava/
     0 Wed Mar 31 19:32:54 EDT 2021 META-INF/maven/com.google.guava/guava/
 10931 Wed Mar 31 19:32:54 EDT 2021 META-INF/maven/com.google.guava/guava/pom.xml
   137 Wed Mar 31 19:32:54 EDT 2021 META-INF/maven/com.google.guava/guava/pom.properties
     0 Wed Mar 31 19:32:54 EDT 2021 com/
     0 Wed Mar 31 19:32:54 EDT 2021 com/google/
     0 Wed Mar 31 19:32:54 EDT 2021 com/google/common/
     0 Wed Mar 31 19:32:54 EDT 2021 com/google/common/base/
  1002 Wed Mar 31 19:32:54 EDT 2021 com/google/common/base/Charsets.class
```